### PR TITLE
Lint entire app tree to include .scss/.sass files in pod-style dirs

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     var formattedResults, mergedTrees, results;
 
     if (type === 'app') {
-      mergedTrees = mergeTrees([this.app.trees.styles]);
+      mergedTrees = mergeTrees([this.app.trees.app]);
 
       return new SassLinter(mergedTrees, this.sassLintOptions);
     } else {

--- a/tests/dummy/app/components/example-component/component.js
+++ b/tests/dummy/app/components/example-component/component.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+});

--- a/tests/dummy/app/components/example-component/style.scss
+++ b/tests/dummy/app/components/example-component/style.scss
@@ -1,0 +1,9 @@
+// SHould throw linting errors
+.funkytown {
+  color: blue; // To test if the styles are still compiled
+  @extend %huh;
+}
+
+#should-also-allowed-by-sass-lint-test-config-yml {
+  color: green;
+}

--- a/tests/dummy/app/components/example-component/template.hbs
+++ b/tests/dummy/app/components/example-component/template.hbs
@@ -1,0 +1,1 @@
+I am an <span class="funkytown">example</span> component

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -20,7 +20,7 @@ function buildAndLint(sourcePath) {
       }
     },
     trees: {
-      styles: sourcePath, // Directory to lint
+      app: sourcePath, // Directory to lint
     },
   });
 
@@ -45,34 +45,53 @@ describe('ember-cli-sass-lint', function() {
     }
   });
 
-  it('The linter should run', function() {
-    return buildAndLint('tests/dummy').then(function() {
-      var firstError = errors[0];
-      var messageIdStrings;
+    it('The linter should run and lint a file in the app/styles dir', function() {
+      return buildAndLint('tests/dummy').then(function() {
+        var appCssError = errors.filter((error) => { return error.filePath === 'app/styles/app.scss' })[0];
+        var messageIdStrings;
 
-      assert.ok(!!firstError,
-        'The linting should occur');
+        assert.ok(!!appCssError,
+          'The app.scss file should be linted');
 
-      assert.equal(firstError.filePath, 'app/styles/app.scss',
-        'The app.scss file should be linted');
+        assert.ok(appCssError.messages.length > 1,
+          'Errors for app.scss should be logged');
 
-      assert.ok(firstError.messages.length > 1,
-        'Errors for app.scss should be logged');
+        /* Create a string of error ID's we can easily test */
 
-      /* Create a string of error ID's we can easily test */
+        messageIdStrings = appCssError.messages.reduce(function(previousValue, currentValue) {
+          return previousValue + ' ' + currentValue.ruleId;
+        }, '');
 
-      messageIdStrings = firstError.messages.reduce(function(previousValue, currentValue) {
-        return previousValue + ' ' + currentValue.ruleId;
-      }, '');
+        assert.include(messageIdStrings, 'no-color-keywords',
+          'Should respect default rules not specified in project\'s sass-lint.yml');
 
-      assert.include(messageIdStrings, 'no-color-keywords',
-        'Should respect default rules not specified in project\'s sass-lint.yml');
-
-
-      assert.notInclude(messageIdStrings, 'no-ids',
-        'Should respect non-default rules specified in project\'s sass-lint.yml');
-
+        assert.notInclude(messageIdStrings, 'no-ids',
+          'Should respect non-default rules specified in project\'s sass-lint.yml');
+      });
     });
-  });
-});
 
+    it('The linter should run and lint a file in the app/components dir', function() {
+      return buildAndLint('tests/dummy').then(function() {
+        var componentCssError = errors.filter((error) => { return error.filePath === 'app/components/example-component/style.scss' })[0];
+        var messageIdStrings;
+
+        assert.ok(!!componentCssError,
+          'The app/components/example-component/style.scss file should be linted');
+
+        assert.ok(componentCssError.messages.length > 1,
+          'Errors for app/components/example-component/style.scss should be logged');
+
+        /* Create a string of error ID's we can easily test */
+
+        messageIdStrings = componentCssError.messages.reduce(function(previousValue, currentValue) {
+          return previousValue + ' ' + currentValue.ruleId;
+        }, '');
+
+        assert.include(messageIdStrings, 'no-color-keywords',
+          'Should respect default rules not specified in project\'s sass-lint.yml');
+
+        assert.notInclude(messageIdStrings, 'no-ids',
+          'Should respect non-default rules specified in project\'s sass-lint.yml');
+      });
+    });
+});


### PR DESCRIPTION
Changes the tree passed to broccoli-sass-lint from `this.app.trees.styles` to `this.app.trees.app`. The latter is a superset of the former, and results in including .scss/.sass files that are colocated with their components in app/components subdirectories.

Fixes #9 