### PR TITLE
Linting in addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,33 @@ module.exports = {
   lintTree: function(type, tree) {
     var mergedTrees;
 
-    if (type === 'app') {
+    if (type === 'addon') {
+      var treePaths = this.registry.app.treePaths;
+      var paths = [];
+
+      ['addon-styles', 'styles'].forEach(function(subtree) {
+        var path = treePaths[subtree];
+
+        /* Use fs.statSync to check if the styles dir exists in
+         addon-name/addon/styles and addon-name/app/styles */
+
+        try {
+          var stats = fs.statSync(path);
+
+          if (stats.isDirectory()) {
+            paths.push(path);
+          }
+        }
+        catch (ignored) {}
+      });
+
+      mergedTrees = mergeTrees(paths.map((path) => {
+        return new Funnel(path);
+      }));
+
+      return new SassLinter(mergedTrees, this.sassLintOptions);
+    }
+    else if (type === 'app') {
       mergedTrees = mergeTrees([
         new Funnel(this.app.trees.app, {
           exclude: ['**/*.js']

--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ module.exports = {
 
   lintTree: function(type, tree) {
     var mergedTrees;
+    var projectName = this.app.project.name();
+    var isAddon = (this.app.name !== projectName);
 
-    if (type === 'addon') {
+    if (isAddon && tree.srcDir === projectName && type === 'addon') {
       var treePaths = this.registry.app.treePaths;
       var paths = [];
 
@@ -47,7 +49,7 @@ module.exports = {
 
       return new SassLinter(mergedTrees, this.sassLintOptions);
     }
-    else if (type === 'app') {
+    else if (!isAddon && tree.destDir === '/' && type === 'app') {
       mergedTrees = mergeTrees([
         new Funnel(this.app.trees.app, {
           exclude: ['**/*.js']

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -22,10 +22,15 @@ function buildAndLint(sourcePath) {
     trees: {
       app: sourcePath, // Directory to lint
     },
+    name: 'dummy',
+    project: {
+      name: () => 'dummy'
+    },
   });
 
   var node = linter.lintTree('app', {
-    tree: sourcePath
+    srcDir: sourcePath,
+    destDir: '/'
   });
 
   builder = new broccoli.Builder(node);


### PR DESCRIPTION
Hey guys,

we started using mono-repository with nested addons for development of our app and this started to be a problem. I found there is already [issue for it](https://github.com/sir-dunxalot/ember-cli-sass-lint/issues/3) and even branch with a fix. So I revamped it, rebased and fixed one issue I found.

The issue was in usage of `fs.stat` instead of `fs.statSync` in `forEach` loop. It worked regardless but I think the intention was different so I fixed it. I replaced plain paths with `new Funnel` as I noticed this is change done in master too.

I also tried to write test for addon logic but I failed miserably. I'm not much familiar with Broccoli, Funnels and such stuff. If there is anybody who would help me with a test I would appreciate it.

So do you mind to review, merge & release a new version? :-) Thank you very much!

Fixes #3 